### PR TITLE
Split shortcuts

### DIFF
--- a/src/components/General/Footer.tsx
+++ b/src/components/General/Footer.tsx
@@ -3,9 +3,11 @@ import Image from "next/image";
 import logoWhite from "../../../public/images/orbitblue.png";
 import mockShortcuts from "@/mockdata/MockShortcuts";
 import BreakLine from "./Breakline";
+import { findInternalShortcuts } from "./Navbar";
 
 const Footer = () => {
   const year = new Date().getFullYear();
+
 
   return (
     <footer>
@@ -39,7 +41,7 @@ const Footer = () => {
         <BreakLine />
         <div className="max-w-4xl m-auto">
           <div className=" flex flex-wrap items-center justify-center">
-            {mockShortcuts.map((link) => (
+            {findInternalShortcuts(mockShortcuts).map((link) => (
               <Link key={link.header} href={link.url} className="ml-2 mr-2 mb-2 hover:text-yellow-500">
                 {link.header}
               </Link>

--- a/src/components/General/Navbar.tsx
+++ b/src/components/General/Navbar.tsx
@@ -2,9 +2,16 @@ import Link from 'next/link';
 import logoWhite from "../../../public/images/orbitwhite.png";
 import Image from "next/image";
 import Dropdown from './Dropdown'; // Adjust the import path based on your project structure
-import mockShortcuts from '@/mockdata/MockShortcuts';
+import mockShortcuts, { ShortcutType, type ShortcutsProps } from '@/mockdata/MockShortcuts';
 import { signIn, signOut, useSession } from "next-auth/react";
 import Icons from './Icons';
+
+export function findInternalShortcuts (shortcuts: ShortcutsProps[]) {
+  for (const shortcutGroup of shortcuts) {
+    if (shortcutGroup.type == ShortcutType.INTERNAL) return shortcutGroup.shortcuts;
+  }
+  return [];
+}
 
 const Navbar = () => {
   const session = useSession();
@@ -45,7 +52,7 @@ const Navbar = () => {
             </button>
           )}
           <Dropdown
-            shortcuts={mockShortcuts}
+            shortcuts={findInternalShortcuts(mockShortcuts)}
             handleLogout={handleLogout}
             handleLogin={handleLogin}
           />

--- a/src/components/HomePage/Shortcut.tsx
+++ b/src/components/HomePage/Shortcut.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
 import type { ShortcutLink } from '@/interfaces/ShortcutLink';
+import Link from 'next/link';
+import { ShortcutType } from '@/mockdata/MockShortcuts';
 
-export const Shortcut = ({ header, description, url }: ShortcutLink) => {
+interface ShortcutProp {
+    type: ShortcutType,
+    shortcut: ShortcutLink,
+}
+
+export const Shortcut = ({ type, shortcut }: ShortcutProp) => {
     return (
-        <a href={url} className='
+        <Link target={type == ShortcutType.EXTERNAL ? '_blank' : ''} href={shortcut.url} className='
         flex flex-col items-center bg-blue-600
         p-4 m-2 rounded-lg w-[280px] hover:bg-blue-800
         '>
             <p className="text-2xl font-bold text-center">
-                {header}
+                {shortcut.header}
             </p>
             <p className='align-left text-subtext'>
-                {description}
+                {shortcut.description}
             </p>
-        </a>
+        </Link>
     )
 }

--- a/src/mockdata/MockShortcuts.tsx
+++ b/src/mockdata/MockShortcuts.tsx
@@ -1,55 +1,75 @@
 import type { ShortcutLink } from "@/interfaces/ShortcutLink"
 
-const mockShortcuts: ShortcutLink[] = [
+export interface ShortcutsProps {
+    type: ShortcutType,
+    shortcuts: ShortcutLink[]
+}
+
+export enum ShortcutType {
+    INTERNAL = 'Internal',
+    EXTERNAL = 'External',
+}
+
+const mockShortcuts: ShortcutsProps[] = [
     {
-        header: 'Your profile',
-        description: 'Check out your profile',
-        url: '/profile/me'
+        type: ShortcutType.INTERNAL,
+        shortcuts: [
+            {
+                header: 'Your profile',
+                description: 'Check out your profile',
+                url: '/profile/me'
+            },
+            {
+                header: 'Calendar',
+                description: 'Check out Orbit events',
+                url: '/calendar',
+            },
+            {
+                header: 'Search for Orbiter',
+                description: 'Search for your friends',
+                url: '/searchpage',
+            },
+            {
+                header: 'Announcements',
+                description: 'Announcements from Orbit',
+                url: '/announcements',
+            },
+            {
+                header: 'Legacy page',
+                description: 'View earlier Orbit teams',
+                url: '/legacy',
+            },
+            {
+                header: 'Meme gallery',
+                description: 'Check out our digital meme page',
+                url: '/memegallery',
+            },
+            {
+                header: 'Orbit Teams',
+                description: 'Explore the teams in Orbit',
+                url: '/team/teamlist',
+            },
+            {
+                header: 'Your team',
+                description: 'See your own team',
+                url: '/team/find',
+            }
+        ],
     },
     {
-        header: 'Contact HR',
-        description: 'Contact HR here',
-        url: 'https://forms.gle/f9J3YDGXo5tU4W6b7',
-    },
-    {
-        header: 'Calendar',
-        description: 'Check out Orbit events',
-        url: '/calendar',
-    },
-    {
-        header: 'Search for Orbiter',
-        description: 'Search for your friends',
-        url: '/searchpage',
-    },
-    {
-        header: 'Announcements',
-        description: 'Announcements from Orbit',
-        url: '/announcements',
-    },
-    {
-        header: 'Legacy page',
-        description: 'View earlier Orbit teams',
-        url: '/legacy',
-    },
-    {
-        header: 'Meme gallery',
-        description: 'Check out our digital meme page',
-        url: '/memegallery',
-    },
-    {
-        header: 'Board Feedback',
-        description: 'Give feedback to the board',
-        url: 'https://docs.google.com/forms/d/e/1FAIpQLSd_EKTsfqqxvPbNl_N8NFASLRZIN_t80nSxuUVTwb-xbcoGmw/viewform?usp=sf_link',
-    },
-    {
-        header: 'Orbit Teams',
-        description: 'Explore the teams in Orbit',
-        url: '/team/teamlist',
-    },
-    {
-        header: 'Your team',
-        description: 'See your own team',
-        url: '/team/find',
+        type: ShortcutType.EXTERNAL,
+        shortcuts: [
+            {
+                header: 'Contact HR',
+                description: 'Contact HR here',
+                url: 'https://forms.gle/f9J3YDGXo5tU4W6b7',
+            },
+            {
+                header: 'Board Feedback',
+                description: 'Give feedback to the board',
+                url: 'https://docs.google.com/forms/d/e/1FAIpQLSd_EKTsfqqxvPbNl_N8NFASLRZIN_t80nSxuUVTwb-xbcoGmw/viewform?usp=sf_link',
+            },
+        ]
     }
 ]
 

--- a/src/mockdata/MockShortcuts.tsx
+++ b/src/mockdata/MockShortcuts.tsx
@@ -69,6 +69,21 @@ const mockShortcuts: ShortcutsProps[] = [
                 description: 'Give feedback to the board',
                 url: 'https://docs.google.com/forms/d/e/1FAIpQLSd_EKTsfqqxvPbNl_N8NFASLRZIN_t80nSxuUVTwb-xbcoGmw/viewform?usp=sf_link',
             },
+            {
+                header: 'Confluence',
+                description: 'Find documentation',
+                url: 'https://wiki.orbitntnu.com'
+            },
+            {
+                header: 'Vaultwarden',
+                description: 'Store yor passwords safely',
+                url: 'https://passwords.orbitntnu.com'
+            },
+            {
+                header: 'Orbit NTNU Website',
+                description: 'Check out Orbit\'s website',
+                url: 'https://orbitntnu.com'
+            },
         ]
     }
 ]

--- a/src/mockdata/MockShortcuts.tsx
+++ b/src/mockdata/MockShortcuts.tsx
@@ -76,7 +76,7 @@ const mockShortcuts: ShortcutsProps[] = [
             },
             {
                 header: 'Vaultwarden',
-                description: 'Store yor passwords safely',
+                description: 'Store your passwords safely',
                 url: 'https://passwords.orbitntnu.com'
             },
             {

--- a/src/views/LandingPageViews/ShortcutsView/index.tsx
+++ b/src/views/LandingPageViews/ShortcutsView/index.tsx
@@ -5,13 +5,23 @@ export const Shortcuts = () => {
 
     return (
         <div>
-            <h2 className="flex justify-center font-bold text-5xl mb-4">
+            <h2 className="flex font-bold text-5xl mb-4">
                 Shortcuts
             </h2>
-            <div className="flex flex-row flex-wrap justify-center">
-                {mockShortcuts.map((infoLink) => (
-                    <Shortcut key={infoLink.header} url={infoLink.url} header={infoLink.header} description={infoLink.description}/>
+            <div className="flex flex-col justify-center">
+
+                {/* Display each group of shortcuts */}
+                {mockShortcuts.map((shortcutGroup) => (
+                    <div key={shortcutGroup.type}>
+                        <h2>{shortcutGroup.type}</h2>
+                        <div className="flex flex-row flex-wrap">
+                            {shortcutGroup.shortcuts.map((infoLink) => (
+                                <Shortcut key={infoLink.header} url={infoLink.url} header={infoLink.header} description={infoLink.description}/>
+                            ))}
+                        </div>                            
+                    </div>
                 ))}
+
             </div>
         </div>
     )

--- a/src/views/LandingPageViews/ShortcutsView/index.tsx
+++ b/src/views/LandingPageViews/ShortcutsView/index.tsx
@@ -8,15 +8,15 @@ export const Shortcuts = () => {
             <h2 className="flex font-bold text-5xl mb-4">
                 Shortcuts
             </h2>
-            <div className="flex flex-col justify-center">
+            <div className="flex flex-col justify-center gap-4">
 
                 {/* Display each group of shortcuts */}
                 {mockShortcuts.map((shortcutGroup) => (
                     <div key={shortcutGroup.type}>
                         <h2>{shortcutGroup.type}</h2>
-                        <div className="flex flex-row flex-wrap">
+                        <div className="flex flex-row flex-wrap justify-center">
                             {shortcutGroup.shortcuts.map((infoLink) => (
-                                <Shortcut key={infoLink.header} url={infoLink.url} header={infoLink.header} description={infoLink.description}/>
+                                <Shortcut key={infoLink.header} type={shortcutGroup.type} shortcut={infoLink}/>
                             ))}
                         </div>                            
                     </div>

--- a/src/views/LandingPageViews/ShortcutsView/index.tsx
+++ b/src/views/LandingPageViews/ShortcutsView/index.tsx
@@ -13,7 +13,7 @@ export const Shortcuts = () => {
                 {/* Display each group of shortcuts */}
                 {mockShortcuts.map((shortcutGroup) => (
                     <div key={shortcutGroup.type}>
-                        <h2>{shortcutGroup.type}</h2>
+                        <h2 className="flex flex-row justify-center">{shortcutGroup.type}</h2>
                         <div className="flex flex-row flex-wrap justify-center">
                             {shortcutGroup.shortcuts.map((infoLink) => (
                                 <Shortcut key={infoLink.header} type={shortcutGroup.type} shortcut={infoLink}/>


### PR DESCRIPTION
## Description

Split shortcut links into internal (for the intranet) and external (that links to other pages)

## Changes

- Shortcut links are grouped into internal and external links
- External links are only shown on landing page, not in the burger menu nor in the footer

Closes #89 